### PR TITLE
Stream API

### DIFF
--- a/server/fs-explorer/index.js
+++ b/server/fs-explorer/index.js
@@ -67,7 +67,34 @@ let scanForMedia = function (root, callback) {
   });
 };
 
+let getMimeType = function (filePath) {
+  let mimeTypes = {
+    '.m3u': 'application/x-mpegurl',
+    '.m3u8': 'application/x-mpegurl',
+    '.3gp': 'video/3gpp',
+    '.mp4': 'video/mp4',
+    '.m4a': 'video/mp4',
+    '.m4p': 'video/mp4',
+    '.m4b': 'video/mp4',
+    '.m4r': 'video/mp4',
+    '.m4v': 'video/x-m4v',
+    '.m1v': 'video/mpeg',
+    '.ogg': 'video/ogg',
+    '.ogv': 'video/ogg',
+    '.mov': 'video/quicktime',
+    '.qt':  'video/quicktime',
+    '.webm': 'video/webm',
+    '.asf': 'video/ms-asf',
+    '.wmv': 'video/x-ms-wmv',
+    '.avi': 'video/x-msvideo',
+    '.flv': 'video/x-flv'
+  };
+
+  return mimeTypes[path.extname(path.basename(filePath)).toLowerCase()];
+};
+
 module.exports = {
   list,
-  scanForMedia
+  scanForMedia,
+  getMimeType
 };

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -58,7 +58,7 @@ router.get('/stream', (req, res) => {
     let chunkSize = (end - start) + 1;
     let mimeType = fileExplorer.getMimeType(filePath);
     if (!mimeType) {
-      return res.status(400).json({message: 'Unsupported video format'});
+      return res.status(statusCodes.BAD_REQUEST).json({message: 'Unsupported video format'});
     }
 
     let headers  = {

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -1,5 +1,6 @@
 let express = require('express');
 let async = require('async');
+let fs = require('fs');
 
 let router = express.Router();
 const statusCodes = require('http-status-codes');
@@ -31,6 +32,51 @@ router.get('/media-files', (req, res) => {
         return res.status(statusCodes.INTERNAL_SERVER_ERROR).json({message: err.message});
       }
       return res.status(statusCodes.OK).json(results);
+    });
+  });
+});
+
+router.get('/stream', (req, res) => {
+  let filePath = req.query.path;
+  fs.stat(req.query.path, (err, stats) => {
+    if (err) {
+      if (err.code == 'ENOENT') {
+        return res.status(statusCodes.NOT_FOUND).json({message: 'File not found at path: ' + filePath});
+      }
+      return res.status(statusCodes.INTERNAL_SERVER_ERROR).json({message: err.message});
+    }
+    let range = req.headers.range;
+    if (!range) {
+      return res.status(statusCodes.REQUESTED_RANGE_NOT_SATISFIABLE).json({message: 'Range not found'});
+    }
+    let positions = range.replace(/bytes=/, '').split('-');
+
+    let start = parseInt(positions[0], 10);
+    let fileSize = stats.size;
+    let end = positions[1] ? parseInt(positions[1], 10) : fileSize - 1;
+
+    let chunkSize = (end - start) + 1;
+    let mimeType = fileExplorer.getMimeType(filePath);
+    if (!mimeType) {
+      return res.status(400).json({message: 'Unsupported video format'});
+    }
+
+    let headers  = {
+      'Content-Range': 'bytes ' + start + ' - ' + end + '/' + fileSize,
+      'Accept-Ranges': 'bytes',
+      'Content-Length': chunkSize,
+      'Content-Type': mimeType
+    };
+
+    res.writeHead(statusCodes.PARTIAL_CONTENT, headers);
+
+    let stream = fs.createReadStream(filePath, {start: start, end: end});
+    stream.on('open', () => {
+      stream.pipe(res);
+    });
+
+    stream.on('error', (err) => {
+      res.status(statusCodes.INTERNAL_SERVER_ERROR).json({message: err.message});
     });
   });
 });


### PR DESCRIPTION
I added an endpoint for streaming video files from local file system and a template (rendered by the server) with a HTML5 video player to test that endpoint.

![screen shot 2018-03-13 at 11 41 29 pm](https://user-images.githubusercontent.com/69436/37380747-d0f1ea7e-2718-11e8-8db6-e3919832289c.png)

I was able to play mp4, ogv and webm videos successfully while AVI and FLV failed to load (probably have to look into the video player).

How to test: start the server and load `http://localhost:8080/api/explorer/stream-test?path=<path/to/video-file>` into the browser.